### PR TITLE
[#116309951] Allow setup frontend with ProxyProtocol support

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -21,6 +21,9 @@ properties:
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"
     default: false
+  ha_proxy.enable_proxy_protocol:
+    description: "Enable port 81 for ProxyProtocol HTTP traffic. Will update X-Forwarded-Proto if dst_port was 443"
+    default: ~
   ha_proxy.ssl_ciphers:
     default: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA:ECDHE-RSA-AES256-CBC-SHA:AES128-SHA256:AES128-SHA
     description: "List of SSL Ciphers that are passed to HAProxy"

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -53,7 +53,7 @@ frontend http-in
 <% end %>
 <% end %>
 
-<% if p("ha_proxy.ssl_pem") %>
+<% if_p("ha_proxy.ssl_pem") do %>
 frontend https-in
     mode http
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -28,6 +28,7 @@ frontend http-in
     bind :80
     option httplog
     option forwardfor
+    reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ http
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
@@ -41,6 +42,7 @@ frontend https-in
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     option httplog
     option forwardfor
+    reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ https
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -25,7 +25,7 @@ defaults
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
-    bind :80
+    bind :80 accept-proxy
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
@@ -37,9 +37,23 @@ frontend http-in
 <% end %>
 
 <% if p("ha_proxy.ssl_pem") %>
-frontend https-in
-    mode http
+# To implement ELB+SSL+ProxyProtocol, we had to split this frontend in two
+# parts because HAProxy expects the ProxyProtocol header outside of the
+# SSL stream, meanwhile ELB sends it inside. The two configurations are:
+#
+#  * A plain TCP+SSL listener to do the SSL termination, and sends to...
+#  * ...a HTTP frontend which will parse the proxy protocol header.
+#
+# More info here: https://serverfault.com/questions/775010/aws-elb-with-ssl-backend-adds-proxy-protocol-inside-ssl-stream
+listen https-in
+    mode tcp
+    option splice-auto
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    server https-accept-proxy-in 127.0.0.1:8081
+
+frontend https-accept-proxy-in
+    mode http
+    bind 127.0.0.1:8081 accept-proxy
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -25,7 +25,7 @@ defaults
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
-    bind :80 accept-proxy
+    bind :80
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
@@ -37,23 +37,9 @@ frontend http-in
 <% end %>
 
 <% if p("ha_proxy.ssl_pem") %>
-# To implement ELB+SSL+ProxyProtocol, we had to split this frontend in two
-# parts because HAProxy expects the ProxyProtocol header outside of the
-# SSL stream, meanwhile ELB sends it inside. The two configurations are:
-#
-#  * A plain TCP+SSL listener to do the SSL termination, and sends to...
-#  * ...a HTTP frontend which will parse the proxy protocol header.
-#
-# More info here: https://serverfault.com/questions/775010/aws-elb-with-ssl-backend-adds-proxy-protocol-inside-ssl-stream
-listen https-in
-    mode tcp
-    option splice-auto
-    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
-    server https-accept-proxy-in 127.0.0.1:8081
-
-frontend https-accept-proxy-in
+frontend https-in
     mode http
-    bind 127.0.0.1:8081 accept-proxy
+    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -22,6 +22,23 @@ defaults
     option dontlognull
     <% end %>
 
+<% if_p("ha_proxy.enable_proxy_protocol") do %>
+frontend http-proxy-protocol-in
+    mode http
+    bind :81 accept-proxy
+    option httplog
+    option forwardfor
+    # dst_port will be replaced by the value from Proxy Protocol header.
+    acl is-ssl  dst_port       443
+    reqidel ^X-Forwarded-Proto:.*
+    reqadd X-Forwarded-Proto:\ http if ! is-ssl
+    reqadd X-Forwarded-Proto:\ https if is-ssl
+    default_backend http-routers
+<% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
+<%= additional_config.split("\n").map{|x| "    #{x}"}.join("\n") %>
+<% end %>
+<% end %>
+
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -53,7 +53,7 @@ frontend http-in
 <% end %>
 <% end %>
 
-<% if p("ha_proxy.ssl_pem") %>
+<% if_p("ha_proxy.ssl_pem") do %>
 frontend https-in
     mode http
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -28,6 +28,7 @@ frontend http-in
     bind :80
     option httplog
     option forwardfor
+    reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ http
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
@@ -41,6 +42,7 @@ frontend https-in
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     option httplog
     option forwardfor
+    reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ https
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -25,7 +25,7 @@ defaults
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
-    bind :80
+    bind :80 accept-proxy
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
@@ -37,9 +37,23 @@ frontend http-in
 <% end %>
 
 <% if p("ha_proxy.ssl_pem") %>
-frontend https-in
-    mode http
+# To implement ELB+SSL+ProxyProtocol, we had to split this frontend in two
+# parts because HAProxy expects the ProxyProtocol header outside of the
+# SSL stream, meanwhile ELB sends it inside. The two configurations are:
+#
+#  * A plain TCP+SSL listener to do the SSL termination, and sends to...
+#  * ...a HTTP frontend which will parse the proxy protocol header.
+#
+# More info here: https://serverfault.com/questions/775010/aws-elb-with-ssl-backend-adds-proxy-protocol-inside-ssl-stream
+listen https-in
+    mode tcp
+    option splice-auto
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    server https-accept-proxy-in 127.0.0.1:8081
+
+frontend https-accept-proxy-in
+    mode http
+    bind 127.0.0.1:8081 accept-proxy
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -25,7 +25,7 @@ defaults
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
-    bind :80 accept-proxy
+    bind :80
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
@@ -37,23 +37,9 @@ frontend http-in
 <% end %>
 
 <% if p("ha_proxy.ssl_pem") %>
-# To implement ELB+SSL+ProxyProtocol, we had to split this frontend in two
-# parts because HAProxy expects the ProxyProtocol header outside of the
-# SSL stream, meanwhile ELB sends it inside. The two configurations are:
-#
-#  * A plain TCP+SSL listener to do the SSL termination, and sends to...
-#  * ...a HTTP frontend which will parse the proxy protocol header.
-#
-# More info here: https://serverfault.com/questions/775010/aws-elb-with-ssl-backend-adds-proxy-protocol-inside-ssl-stream
-listen https-in
-    mode tcp
-    option splice-auto
-    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
-    server https-accept-proxy-in 127.0.0.1:8081
-
-frontend https-accept-proxy-in
+frontend https-in
     mode http
-    bind 127.0.0.1:8081 accept-proxy
+    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -22,6 +22,23 @@ defaults
     option dontlognull
     <% end %>
 
+<% if_p("ha_proxy.enable_proxy_protocol") do %>
+frontend http-proxy-protocol-in
+    mode http
+    bind :81 accept-proxy
+    option httplog
+    option forwardfor
+    # dst_port will be replaced by the value from Proxy Protocol header.
+    acl is-ssl  dst_port       443
+    reqidel ^X-Forwarded-Proto:.*
+    reqadd X-Forwarded-Proto:\ http if ! is-ssl
+    reqadd X-Forwarded-Proto:\ https if is-ssl
+    default_backend http-routers
+<% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
+<%= additional_config.split("\n").map{|x| "    #{x}"}.join("\n") %>
+<% end %>
+<% end %>
+
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http


### PR DESCRIPTION
[#116309951 X-Forwarded headers available to applications](https://www.pivotaltracker.com/n/projects/1275640/stories/116309951)
## What

As a tenant deploying an application to the PaaS, I want an X-Forwarded-Proto and X-Forwarded-For headers to be available to my application so that the application can determine whether it is being served externally over HTTPS.

In order to implement this, we need to get the client origin IP from the ELB in front of HAProxy, for that we want to use [ProxyProtocols](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) in [ELB](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html).
## Implementation notes

During the implementation of this story, we found out that ELB adds the ProxyProtocol header inside the SSL stream when it does re-encryption and uses a SSL backend, but haproxy expects this header outside of the  SSL stream. See [this question in serverfault for details](http://serverfault.com/questions/775010/aws-elb-with-ssl-backend-adds-proxy-protocol-inside-ssl-stream question)

To solve it we must:
- Either implement two frontends in Haproxy
- Disable SSL in ELB.

We decided to go for the second option but implemented the first option and reverted for reference and documentation.
## Context

In this story we implemented:
- new frontend with plain HTTP and ProxyProtocol enable that listens on port 81.
- it can be optionally enabled with the option `ha_proxy.enable_proxy_protocol` in the manifest. This allows us decide in the manifest if we want to enable ProxyProtocol or not.
- it will automatically setup the header `X-Forwarded-Proto` if the ProxyProtocol destination port is 443.
- `X-Forwarded-For` will work as usual in haproxy and append the client address.
- We delete any incoming `X-Forwarded-Proto` from the client request to avoid forgery.

Note that in HAProxy, [when using `accept-proxy`](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.1-accept-proxy), all the variables related to the TCP connection will be updated with the info from the ProxyProtocol header.
## How to test this

The best option is test this together with the associated PR in paas-cf (https://github.com/alphagov/paas-cf/pull/247)
## Tag after merge

After this PR is merged you must tag the latest commit as 0.0.2 and update paas-cf to point to the tag.
## Who?

Anyone but @keymon or @combor
