### PR TITLE
[#121933113] User-Agent frontend

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -50,6 +50,11 @@ properties:
     default: 80
   ha_proxy.additional_frontend_config:
     description: "Configurations which are passed to the http-in and https-in configuration block"
+  ha_proxy.enable_healthcheck_frontend:
+    description: |
+      Add a frontend to set 'User-Agent: HTTP-Monitor/1.1' header on requests to backend.
+      Especially useful for gorouter healthcheck.
+    default: false
 
   cc.allow_app_ssh_access:
     default: true

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -39,7 +39,7 @@ frontend http-proxy-protocol-in
 <% end %>
 <% end %>
 
-<% unless p("ha_proxy.disable_http") %>
+<% if p("ha_proxy.disable_http") == "false" %>
 frontend http-in
     mode http
     bind :80

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -72,6 +72,16 @@ frontend ssl-in
     default_backend tcp-routers
 <% end %>
 
+<% if p("ha_proxy.enable_healthcheck_frontend") == "true" %>
+frontend healthcheck
+    mode http
+    bind :82
+    option httplog
+    reqidel ^User-Agent:.*
+    reqadd User-Agent:\ HTTP-Monitor/1.1
+    default_backend http-routers
+<% end %>
+
 backend http-routers
     mode http
     balance roundrobin

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -39,7 +39,7 @@ frontend http-proxy-protocol-in
 <% end %>
 <% end %>
 
-<% unless p("ha_proxy.disable_http") %>
+<% if p("ha_proxy.disable_http") == "false" %>
 frontend http-in
     mode http
     bind :80

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -72,6 +72,16 @@ frontend ssl-in
     default_backend tcp-routers
 <% end %>
 
+<% if p("ha_proxy.enable_healthcheck_frontend") == "true" %>
+frontend healthcheck
+    mode http
+    bind :82
+    option httplog
+    reqidel ^User-Agent:.*
+    reqadd User-Agent:\ HTTP-Monitor/1.1
+    default_backend http-routers
+<% end %>
+
 backend http-routers
     mode http
     balance roundrobin


### PR DESCRIPTION
# What

Story: [Fix Router issue for zero downtime deploy](https://www.pivotaltracker.com/story/show/121933113)

[Gorouter](https://github.com/cloudfoundry/gorouter) provides a special healthcheck response when a request has the 'User-Agent: HTTP-Monitor/1.1' HTTP header. Unfortunately ELBs don't send this header.
This PR adds a HAProxy frontend to set this header on requests to the default_backend (in our case gorouter).
# How to review

It can be tricky to test in isolation. I suggest to test with the paas-cf PR that includes this one.
# After merge

Create a new tag on the merge commit and update the relevant commit in the paas-cf PR.
# Who can review

Anyone but @combor, @timmow  or myself.
