### PR TITLE
[#121933113] Fix if condtions in templates

### DIFF
--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -39,7 +39,7 @@ frontend http-proxy-protocol-in
 <% end %>
 <% end %>
 
-<% if p("ha_proxy.disable_http") == "false" %>
+<% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
     bind :80
@@ -72,7 +72,7 @@ frontend ssl-in
     default_backend tcp-routers
 <% end %>
 
-<% if p("ha_proxy.enable_healthcheck_frontend") == "true" %>
+<% if p("ha_proxy.enable_healthcheck_frontend") %>
 frontend healthcheck
     mode http
     bind :82

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -39,7 +39,7 @@ frontend http-proxy-protocol-in
 <% end %>
 <% end %>
 
-<% if p("ha_proxy.disable_http") == "false" %>
+<% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http
     bind :80
@@ -72,7 +72,7 @@ frontend ssl-in
     default_backend tcp-routers
 <% end %>
 
-<% if p("ha_proxy.enable_healthcheck_frontend") == "true" %>
+<% if p("ha_proxy.enable_healthcheck_frontend") %>
 frontend healthcheck
     mode http
     bind :82


### PR DESCRIPTION
# What

We were under the assumption that p() returns only strings, but the
"true" or "false" strings are actually converted to booleans by the YAML
parser.

This fixes the tests to consider the boolean value.
# How to test

The rendering can be tested with something like:

```
$ aws s3 cp s3://hector-state/cf-manifest.yml /tmp/cf-manifest.yml --region eu-west-1 
$ ./platform-tests/bosh-template-renderer/render.rb  ../paas-haproxy-release/jobs/haproxy/templates/haproxy.ctmpl.erb ../paas-haproxy-release/jobs/haproxy/spec /tmp/cf-manifest.yml
```
# Who can review

Anyone but myself
