### PR TITLE
WIP: [#132170169] Apex domain HSTS configuration

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -55,7 +55,14 @@ properties:
       Add a frontend to set 'User-Agent: HTTP-Monitor/1.1' header on requests to backend.
       Especially useful for gorouter healthcheck.
     default: false
-
+  ha_proxy.hsts.enable:
+    description: Enable serving HSTS headers on all HTTP responses
+    default: false
+  ha_proxy.hsts.apex_domain:
+    description: |
+      Domain apex on which to serve HSTS preload headers
+      Leave blank to disable preload on apex domain
+    default: ''
   cc.allow_app_ssh_access:
     default: true
     description: "Allow users to change the value of the app-level allow_ssh attribute"

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -33,6 +33,10 @@ frontend http-proxy-protocol-in
     reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ http if ! is-ssl
     reqadd X-Forwarded-Proto:\ https if is-ssl
+    <% if p("ha_proxy.hsts.apex_domain") != '' %>
+    acl host_apex hdr(host) -i <%= p('ha_proxy.hsts.apex_domain') %>
+    use_backend http-routers-apex if host_apex
+    <% end %>
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
 <%= additional_config.split("\n").map{|x| "    #{x}"}.join("\n") %>
@@ -47,6 +51,10 @@ frontend http-in
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ http
+    <% if p("ha_proxy.hsts.apex_domain") != '' %>
+    acl host_apex hdr(host) -i <%= p('ha_proxy.hsts.apex_domain') %>
+    use_backend http-routers-apex if host_apex
+    <% end %>
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
 <%= additional_config.split("\n").map{|x| "    #{x}"}.join("\n") %>
@@ -61,6 +69,10 @@ frontend https-in
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
     reqadd X-Forwarded-Proto:\ https
+    <% if p("ha_proxy.hsts.apex_domain") != '' %>
+    acl host_apex hdr(host) -i <%= p('ha_proxy.hsts.apex_domain') %>
+    use_backend http-routers-apex if host_apex
+    <% end %>
     default_backend http-routers
 <% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
 <%= additional_config.split("\n").map{|x| "    #{x}"}.join("\n") %>
@@ -85,10 +97,25 @@ frontend healthcheck
 backend http-routers
     mode http
     balance roundrobin
+    <% if p("ha_proxy.hsts.enable") %>
+    acl no_sts_header res.hdr_cnt(strict-transport-security) eq 0
+    http-response add-header Strict-Transport-Security max-age=31536000 if no_sts_header
+    <% end %>
+    <% p("ha_proxy.go_router.servers").each_with_index do |ip, index| %>
+        server node<%= index %> <%= ip %>:<%= p("ha_proxy.go_router.port") %> check inter 1000
+    <% end %>
+
+<% if p("ha_proxy.hsts.apex_domain") != '' %>
+backend http-routers-apex
+    mode http
+    balance roundrobin
+    acl no_sts_header res.hdr_cnt(strict-transport-security) eq 0
+    http-response add-header Strict-Transport-Security max-age=31536000;\ includeSubDomains;\ preload if no_sts_header
 
     <% p("ha_proxy.go_router.servers").each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("ha_proxy.go_router.port") %> check inter 1000
     <% end %>
+<% end %>
 
 backend tcp-routers
     mode tcp


### PR DESCRIPTION
# What

Story: [Fix credential leakage in aws-account-wide-terraform](https://www.pivotaltracker.com/story/show/132170169)

The HSTS configuration was previously configured in property `ha_proxy.additional_frontend_config`. We now need a more customised configuration because we want to handle the HSTS configuration for the apex domain as well, which is slightly different than the rest. The HAProxy configuration is now less generic but it was never really generic anyway.
# How to review

Review as part of https://github.com/alphagov/paas-cf/pull/549 and https://github.gds/government-paas/aws-account-wide-terraform/pull/63. Refer to instructions found in https://github.com/alphagov/paas-cf/pull/549 for merging.
# Who

Anyone but me or @saliceti 
