### PR TITLE
[#132082633] Conditionally restart rsyslog

### DIFF
--- a/jobs/haproxy/templates/haproxy_ctl
+++ b/jobs/haproxy/templates/haproxy_ctl
@@ -46,8 +46,10 @@ configure_syslog() {
         chmod 755 "${LOG_DIR}"
     fi
 
-    cp $SYSLOG_CONFIG /etc/rsyslog.d/01-haproxy_syslog.conf
-    /usr/sbin/service rsyslog restart
+    if ! cmp $SYSLOG_CONFIG /etc/rsyslog.d/01-haproxy_syslog.conf; then
+        cp $SYSLOG_CONFIG /etc/rsyslog.d/01-haproxy_syslog.conf
+        /usr/sbin/service rsyslog restart
+    fi
 }
 
 start_haproxy() {


### PR DESCRIPTION
# What

[#132082633 - Router HAProxy restarts rsyslog without reason](https://www.pivotaltracker.com/n/projects/1275640/stories/132082633)

We want to reduce the number of unnecessary restarts of rsyslog, as the amount of time it takes to restart has been known to cause deployment failures.

A condition which only restarts rsyslog if the configuration file has changed has been added.
# How to review

**Important:** Before merging, make sure the temporary commit is removed.

This is a small change so testing should be done with Bosh-lite to avoid the time it takes to create a release and deploy it in the pipeline:
1. Check that you have `vagrant`, `Virtualbox`, and the Bosh CLI installed (you can install bosh_cli with `gem install bosh_cli`).
2. Start bosh-lite:
   
   ```
   git clone https://github.com/cloudfoundry/bosh-lite && cd bosh-lite
   vagrant up
   
   bosh target 192.168.50.4 lite # Login: admin Pass: admin
   ```
3. Upload the stemcell:
   
   ```
   bosh upload stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3262.2
   ```
4. Build the release.
   
   `cd` to the paas-haproxy-release repository, check out this branch and run:
   
   ```
   bosh create release --with-tarball
   # Change the following path to your created release
   bosh upload release /Users/henryknott/paas/repositories/paas-haproxy-release/dev_releases/haproxy/haproxy-0+dev.3.tgz
   ```
5. `cd` back to your bosh-lite directory and log into the virtual machine:
   
   ```
   vagrant ssh
   ```
6. Generate the manifest:
   
   ```
   cat > /tmp/manifest.yml <<EOF
   ---
   name: release-test
   director_uuid: DIRECTOR_UUID
   
   releases:
   - name: haproxy
     version: latest
   
   networks:
   - name: default
     subnets:
     - range: 10.244.0.0/28
       reserved: [10.244.0.1]
       static: [10.244.0.2,10.244.0.6,10.244.0.10]
       cloud_properties:
         name: random
   
   resource_pools:
   - name: default
     stemcell:
       name: bosh-warden-boshlite-ubuntu-trusty-go_agent
       version: "3262.2"
     network: default
     cloud_properties: {}
   
   compilation:
     workers: 2
     network: default
     cloud_properties: {}
   
   update:
     canaries: 1
     canary_watch_time: 60000
     update_watch_time: 60000
     max_in_flight: 2
   
   jobs:
   - name: router
     templates:
     - name: haproxy
       release: haproxy
     instances: 1
     resource_pool: default
     networks:
     - name: default
       static_ips:
       - 10.244.0.2
   EOF
   ```
7. Change `DIRECTOR_UUID` to whatever `bosh status --uuid` yields.
8. Deploy:
   
   ```
   bosh deployment /tmp/manifest.yml
   bosh deploy
   ```
9. SSH into the virtual machine:
   
   ```
   bosh ssh router
   sudo su -
   ```
10. Check the start time of the rsyslogd process:
    
    ```
    ps aux | grep rsyslogd
    ```
11. Restart haproxy. When you check the start time of the rsyslogd process it should be the same:
    
    ```
    monit restart haproxy
    watch monit summary    # until it is running
    ps aux | grep rsyslogd # the start time should not have changed
    ```
12. Add any kind of change to this file: `/var/vcap/jobs/haproxy/config/haproxy_syslog.conf` and restart haproxy as above. The rsyslogd process should have restarted this time.
## How to merge
- Remove the temporary commit
- Merge as normal
- Delete the remote branch
- Tag the merge commit as `0.0.5` and push the tag

At the time of writing no corresponding paas-cf pull request has been raised. This is because this release can be tested in isolation using Bosh-lite
# Who

Anyone but me
