### PR TITLE
[#SUPPORT] Capture the Host header for logging

### DIFF
--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -26,6 +26,7 @@ defaults
 frontend http-proxy-protocol-in
     mode http
     bind :81 accept-proxy
+    capture request header Host len 128
     option httplog
     option forwardfor
     # dst_port will be replaced by the value from Proxy Protocol header.
@@ -43,6 +44,7 @@ frontend http-proxy-protocol-in
 frontend http-in
     mode http
     bind :80
+    capture request header Host len 128
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
@@ -57,6 +59,7 @@ frontend http-in
 frontend https-in
     mode http
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    capture request header Host len 128
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*

--- a/jobs/haproxy/templates/haproxy.ctmpl.erb
+++ b/jobs/haproxy/templates/haproxy.ctmpl.erb
@@ -26,6 +26,7 @@ defaults
 frontend http-proxy-protocol-in
     mode http
     bind :81 accept-proxy
+    capture request header Host len 128
     option httplog
     option forwardfor
     # dst_port will be replaced by the value from Proxy Protocol header.
@@ -43,6 +44,7 @@ frontend http-proxy-protocol-in
 frontend http-in
     mode http
     bind :80
+    capture request header Host len 128
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*
@@ -57,6 +59,7 @@ frontend http-in
 frontend https-in
     mode http
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    capture request header Host len 128
     option httplog
     option forwardfor
     reqidel ^X-Forwarded-Proto:.*


### PR DESCRIPTION
What?
-----

Currently we capture the access log of the HAProxy in front of our gorouters.

Today I was troubleshooting some spike in the request latency, and I wanted to check the access log from the HAProxy in logsearch. But I found out that I could not correlate the requests with the applications because the log messages do not include the Host header.

That is valuable information, but in order to identify for which application each request is, we need to log the Host header.

To do so, we add the instruction `capture request header` for each required frontend. The current log format `httplog` will print the list  of captured headers[1], so it is not necessary to change the format.

[1] http://blog.haproxy.com/2012/10/29/haproxy-log-customization/

The [logsearch-for-cloudfoundry logsearch filters](https://github.com/alphagov/paas-logsearch-for-cloudfoundry/blob/gds_master/src/logsearch-config/src/logstash-filters/snippets/platform-haproxy.conf#L17) parse properly these captured headers.

How to review?
-------------

The best option is test it with paas-cf directly. Other PR is coming.

Who?
----

Anyone but @keymon