### PR TITLE
Add UAA certificate to haproxy

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -11,10 +11,14 @@ templates:
   haproxy_syslog.conf.erb:   config/haproxy_syslog.conf
   haproxy_ctl:               bin/haproxy_ctl
   cert.pem.erb:              config/cert.pem
+  uaa_cert.pem.erb:          config/uaa_cert.pem
 
 properties:
   ha_proxy.ssl_pem:
     description: "SSL certificate (PEM file)"
+    default: ~
+  ha_proxy.uaa_ssl_pem:
+    description: "UAA SSL certificate (PEM file)"
     default: ~
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -76,7 +76,7 @@ frontend http-redirect-in
 listen https-in
     mode tcp
     option splice-auto
-    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem crt /var/vcap/jobs/haproxy/config/uaa_cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     capture request header Host len 128
     server http-proxy-protocol-in 127.0.0.1:81
 <% end %>

--- a/jobs/haproxy/templates/uaa_cert.pem.erb
+++ b/jobs/haproxy/templates/uaa_cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p("ha_proxy.uaa_ssl_pem", "") %>


### PR DESCRIPTION
## What

The gorouter will handle traffic from both the router ELBs and the UAA elbs but
it only has the certificates for the router domains. This will allow us to run
UAA behind the gorouter.

## How to review

TODO: work in progress

## Who can review

not me or @paroxp 
