### PR TITLE
[#151948132] Use the new health check endpoint on gorouter

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -46,12 +46,14 @@ properties:
   ha_proxy.go_router.port:
     description: "Listening port for the Go Router"
     default: 80
+  ha_proxy.go_router.healthcheck_port:
+    description: "Listening port for the Go Router health check"
+    default: 8080
   ha_proxy.additional_frontend_config:
     description: "Configurations which are passed to the http-in and https-in configuration block"
   ha_proxy.enable_healthcheck_frontend:
     description: |
-      Add a frontend to set 'User-Agent: HTTP-Monitor/1.1' header on requests to backend.
-      Especially useful for gorouter healthcheck.
+      Add a frontend for health checks on port 82.
     default: false
   ha_proxy.enable_http_redirect_frontend:
     description: |

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -104,11 +104,3 @@ backend http-routers
     <% p("ha_proxy.go_router.servers").each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("ha_proxy.go_router.port") %> check inter 1000
     <% end %>
-
-backend tcp-routers
-    mode tcp
-    balance roundrobin
-
-    <% p("ha_proxy.go_router.servers").each_with_index do |ip, index| %>
-        server node<%= index %> <%= ip %>:<%= p("ha_proxy.go_router.port") %> check inter 1000
-    <% end %>

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -86,9 +86,15 @@ frontend healthcheck
     mode http
     bind :82
     option httplog
-    reqidel ^User-Agent:.*
-    reqadd User-Agent:\ HTTP-Monitor/1.1
-    default_backend http-routers
+    default_backend http-healthcheck-routers
+
+backend http-healthcheck-routers
+    mode http
+    balance roundrobin
+
+    <% p("ha_proxy.go_router.servers").each_with_index do |ip, index| %>
+        server node<%= index %> <%= ip %>:<%= p("ha_proxy.go_router.healthcheck_port") %> check inter 1000
+    <% end %>
 <% end %>
 
 backend http-routers


### PR DESCRIPTION
## What

The new Go Router health check is available on a different port (8080) therefore we register a new backend and point the health check frontend to it.

Minor changes:
 * the tcp-routers backend was removed as it was not used anymore

## How to review

Test is together with https://github.com/alphagov/paas-cf/pull/1108

## Who can review

Not @bandesz