### PR TITLE
Upgrade to haproxy 1.5.19

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,9 +1,9 @@
 ---
-haproxy/haproxy-1.5.14.tar.gz:
-  object_id: 02657a44-3292-4e0b-8b18-bcad061a2381
-  sha: 159f5beb8fdc6b8059ae51b53dc935d91c0fb51f
-  size: 1345345
-haproxy/pcre-8.37.tar.gz:
-  object_id: 22601a5f-4ef4-4621-80aa-0fa1f8067db6
-  sha: 4a24a20c61347d8da4edc86d5475aaf70ac146bb
-  size: 2041593
+haproxy/haproxy-1.5.19.tar.gz:
+  size: 1362834
+  object_id: c1a80f45-f732-4184-917b-ce2cf796ffad
+  sha: 8aa56f4cca4c1bf27c82f60ec2a040f91acb0bc1
+haproxy/pcre-8.40.tar.gz:
+  size: 2065161
+  object_id: 7d3a2a29-6c80-40b6-bf77-74d337b99cea
+  sha: 10384eb3d411794cc15f55b9d837d3f69e35391e

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -2,15 +2,15 @@
 set -e
 
 echo "Extracting pcre..."
-tar xzf haproxy/pcre-8.37.tar.gz
-cd pcre-8.37
+tar xzf haproxy/pcre-8.40.tar.gz
+cd pcre-8.40
 ./configure
 make
 make install
 cd ..
 
-tar xzf haproxy/haproxy-1.5.14.tar.gz
-cd haproxy-1.5.14
+tar xzf haproxy/haproxy-1.5.19.tar.gz
+cd haproxy-1.5.19
 make TARGET=linux2628 USE_OPENSSL=1 USE_STATIC_PCRE=1
 mkdir ${BOSH_INSTALL_TARGET}/bin
 cp haproxy ${BOSH_INSTALL_TARGET}/bin/

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,6 +1,6 @@
 ---
 name: haproxy
 files:
-- haproxy/haproxy-1.5.14.tar.gz
-- haproxy/pcre-8.37.tar.gz
+- haproxy/haproxy-1.5.19.tar.gz
+- haproxy/pcre-8.40.tar.gz
 - haproxy/utils.sh


### PR DESCRIPTION
This PR upgrades to HAProxy 1.5.19 and PCRE 8.40.

This uses blobs and SHAs from cf-release. We should address this.