### PR TITLE
[166541517] Add additional frontend for ALBs

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -22,6 +22,9 @@ properties:
   ha_proxy.enable_proxy_protocol:
     description: "Enable port 81 for ProxyProtocol HTTP traffic. Will update X-Forwarded-Proto if dst_port was 443"
     default: ~
+  ha_proxy.enable_proxy_frontend:
+    description: "Enable port 8443 for HTTPS traffic."
+    default: ~
   ha_proxy.ssl_ciphers:
     default: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-CBC-SHA256:ECDHE-RSA-AES256-CBC-SHA384:ECDHE-RSA-AES128-CBC-SHA:ECDHE-RSA-AES256-CBC-SHA:AES128-SHA256:AES128-SHA
     description: "List of SSL Ciphers that are passed to HAProxy"

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -40,6 +40,19 @@ frontend http-proxy-protocol-in
 <% end %>
 <% end %>
 
+<% if_p("ha_proxy.enable_proxy_frontend") do %>
+frontend https-proxy-in
+    mode http
+    bind :8443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    capture request header Host len 128
+    option httplog
+    option forwardfor
+    default_backend http-routers
+<% if_p("ha_proxy.additional_frontend_config") do |additional_config| %>
+<%= additional_config.split("\n").map{|x| "    #{x}"}.join("\n") %>
+<% end %>
+<% end %>
+
 <% unless p("ha_proxy.disable_http") %>
 frontend http-in
     mode http


### PR DESCRIPTION
What 
------

Port 443 is currently configured for the classic ELBs with proxy protocol enabled. This PR adds an additional https frontend for ALBs which don't require proxy protocol.

How to review
-------

- Deploy to your dev env

Who can review
--------

Not me